### PR TITLE
Implement `GetResourceGovAddr`

### DIFF
--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -65,9 +65,9 @@ func NewClient(ctx context.Context,
 	}, nil
 }
 
-func (c *client) GetResourceGovAddr(_ context.Context, resourceDID string) (string, error) {
+func (c *client) GetResourceGovAddr(ctx context.Context, resourceDID string) (string, error) {
 	query := buildGetResourceGovAddrRequest(resourceDID)
-	response, err := c.cognitariumClient.Select(context.Background(), &cgschema.QueryMsg_Select{Query: query})
+	response, err := c.cognitariumClient.Select(ctx, &cgschema.QueryMsg_Select{Query: query})
 	if err != nil {
 		return "", err
 	}

--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
 	dvschema "github.com/axone-protocol/axone-contract-schema/go/dataverse-schema/v5"
 	"google.golang.org/grpc"

--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -10,6 +10,9 @@ import (
 )
 
 type Client interface {
+	// GetResourceGovAddr returns the governance address of a resource.
+	// It queries the cognitarium to get the governance address (law-stone contract address)
+	// of a resource. The resource is identified by its DID.
 	GetResourceGovAddr(context.Context, string) (string, error)
 	ExecGov(context.Context, string, string) (interface{}, error)
 }

--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -20,22 +20,15 @@ type Client interface {
 type client struct {
 	dataverseClient   dvschema.QueryClient
 	cognitariumClient cgschema.QueryClient
-	cognitariumAddr   string
 }
 
-func NewDataverseClient(ctx context.Context,
+func NewDataverseClient(
 	dataverseClient dvschema.QueryClient,
 	cognitariumClient cgschema.QueryClient,
 ) (Client, error) {
-	cognitariumAddr, err := getCognitariumAddr(ctx, dataverseClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cognitarium address: %w", err)
-	}
-
 	return &client{
 		dataverseClient,
 		cognitariumClient,
-		cognitariumAddr,
 	}, nil
 }
 
@@ -61,7 +54,6 @@ func NewClient(ctx context.Context,
 	return &client{
 		dataverseClient,
 		cognitariumClient,
-		cognitariumAddr,
 	}, nil
 }
 

--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -22,7 +22,8 @@ type client struct {
 
 func NewDataverseClient(ctx context.Context,
 	dataverseClient dvschema.QueryClient,
-	cognitariumClient cgschema.QueryClient) (Client, error) {
+	cognitariumClient cgschema.QueryClient,
+) (Client, error) {
 	cognitariumAddr, err := getCognitariumAddr(ctx, dataverseClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cognitarium address: %w", err)
@@ -69,16 +70,16 @@ func (c *client) GetResourceGovAddr(_ context.Context, resourceDID string) (stri
 	}
 
 	if len(response.Results.Bindings) != 1 {
-		return "", fmt.Errorf("could not find governance code")
+		return "", NewDVError(ErrNoResult, nil)
 	}
 
 	codeBinding, ok := response.Results.Bindings[0]["code"]
 	if !ok {
-		return "", fmt.Errorf("could not find governance code")
+		return "", NewDVError(ErrVarNotFound, nil)
 	}
 	code, ok := codeBinding.ValueType.(cgschema.URI)
 	if !ok {
-		return "", fmt.Errorf("could not decode governance code")
+		return "", NewDVError(ErrType, fmt.Errorf("expected URI, got %T", codeBinding.ValueType))
 	}
 	return string(*code.Value.Full), nil
 }

--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -2,7 +2,6 @@ package dataverse
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
@@ -21,7 +20,9 @@ type client struct {
 	cognitariumAddr   string
 }
 
-func NewDataverseClient(ctx context.Context, dataverseClient dvschema.QueryClient, cognitariumClient cgschema.QueryClient) (Client, error) {
+func NewDataverseClient(ctx context.Context,
+	dataverseClient dvschema.QueryClient,
+	cognitariumClient cgschema.QueryClient) (Client, error) {
 	cognitariumAddr, err := getCognitariumAddr(ctx, dataverseClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cognitarium address: %w", err)
@@ -62,8 +63,6 @@ func NewClient(ctx context.Context,
 
 func (c *client) GetResourceGovAddr(_ context.Context, resourceDID string) (string, error) {
 	query := buildGetResourceGovAddrRequest(resourceDID)
-	queryB, _ := json.Marshal(query)
-	fmt.Printf("query : %s", queryB)
 	response, err := c.cognitariumClient.Select(context.Background(), &cgschema.QueryMsg_Select{Query: query})
 	if err != nil {
 		return "", err

--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -22,16 +22,6 @@ type client struct {
 	cognitariumClient cgschema.QueryClient
 }
 
-func NewDataverseClient(
-	dataverseClient dvschema.QueryClient,
-	cognitariumClient cgschema.QueryClient,
-) (Client, error) {
-	return &client{
-		dataverseClient,
-		cognitariumClient,
-	}, nil
-}
-
 func NewClient(ctx context.Context,
 	grpcAddr, contractAddr string,
 	opts ...grpc.DialOption,
@@ -55,32 +45,6 @@ func NewClient(ctx context.Context,
 		dataverseClient,
 		cognitariumClient,
 	}, nil
-}
-
-func (c *client) GetResourceGovAddr(ctx context.Context, resourceDID string) (string, error) {
-	query := buildGetResourceGovAddrRequest(resourceDID)
-	response, err := c.cognitariumClient.Select(ctx, &cgschema.QueryMsg_Select{Query: query})
-	if err != nil {
-		return "", err
-	}
-
-	if len(response.Results.Bindings) != 1 {
-		return "", NewDVError(ErrNoResult, nil)
-	}
-
-	codeBinding, ok := response.Results.Bindings[0]["code"]
-	if !ok {
-		return "", NewDVError(ErrVarNotFound, nil)
-	}
-	code, ok := codeBinding.ValueType.(cgschema.URI)
-	if !ok {
-		return "", NewDVError(ErrType, fmt.Errorf("expected URI, got %T", codeBinding.ValueType))
-	}
-	return string(*code.Value.Full), nil
-}
-
-func (c *client) ExecGov(_ context.Context, _ string, _ string) (interface{}, error) {
-	panic("not implemented")
 }
 
 func getCognitariumAddr(ctx context.Context, dvClient dvschema.QueryClient) (string, error) {

--- a/dataverse/client_test.go
+++ b/dataverse/client_test.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	schema "github.com/axone-protocol/axone-contract-schema/go/dataverse-schema/v5"
+	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+	dvschema "github.com/axone-protocol/axone-contract-schema/go/dataverse-schema/v5"
 	"github.com/axone-protocol/axone-sdk/dataverse"
 	"github.com/axone-protocol/axone-sdk/testutil"
 	. "github.com/smartystreets/goconvey/convey"
@@ -43,8 +44,8 @@ func TestClient_NewDataverseClient(t *testing.T) {
 				mockClient.EXPECT().
 					Dataverse(gomock.Any(), gomock.Any()).
 					Return(
-						&schema.DataverseResponse{
-							TriplestoreAddress: schema.Addr(test.wantAddr),
+						&dvschema.DataverseResponse{
+							TriplestoreAddress: dvschema.Addr(test.wantAddr),
 						},
 						test.returnedErr,
 					).
@@ -61,6 +62,151 @@ func TestClient_NewDataverseClient(t *testing.T) {
 							So(client, ShouldNotBeNil)
 						} else {
 							So(client, ShouldBeNil)
+						}
+					})
+				})
+			})
+		})
+	}
+}
+
+func toAddress[T any](v T) *T {
+	return &v
+}
+
+func TestClient_GetResourceGovAddr(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceDID   string
+		response      *cgschema.SelectResponse
+		responseError error
+		wantErr       error
+		wantResult    string
+	}{
+		{
+			name:        "ask for good did response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{
+						{
+							"code": cgschema.Value{
+								ValueType: cgschema.URI{
+									Type:  "uri",
+									Value: cgschema.IRI{Full: toAddress(cgschema.IRI_Full("foo"))},
+								},
+							},
+						},
+					},
+				},
+			},
+			responseError: nil,
+			wantErr:       nil,
+			wantResult:    "foo",
+		},
+		{
+			name:          "grpc error",
+			resourceDID:   "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response:      nil,
+			responseError: fmt.Errorf("gRPC: connection refused"),
+			wantErr:       fmt.Errorf("gRPC: connection refused"),
+			wantResult:    "",
+		},
+		{
+			name:        "invalid variable binding in response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{
+						{
+							"invalid": cgschema.Value{},
+						},
+					},
+				},
+			},
+			responseError: nil,
+			wantErr:       fmt.Errorf("could not find governance code"),
+			wantResult:    "",
+		},
+		{
+			name:        "no binding in response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{},
+				},
+			},
+			responseError: nil,
+			wantErr:       fmt.Errorf("could not find governance code"),
+			wantResult:    "",
+		},
+		{
+			name:        "invalid value type in response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{
+						{
+							"code": cgschema.Value{
+								ValueType: cgschema.BlankNode{
+									Type:  "blank_node",
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			responseError: nil,
+			wantErr:       fmt.Errorf("could not decode governance code"),
+			wantResult:    "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Convey("Given a mocked dataverse client", t, func() {
+				controller := gomock.NewController(t)
+				defer controller.Finish()
+
+				mockDataverseClient := testutil.NewMockDataverseQueryClient(controller)
+				mockDataverseClient.EXPECT().
+					Dataverse(gomock.Any(), gomock.Any()).
+					Return(&dvschema.DataverseResponse{TriplestoreAddress: "bar"}, nil).
+					Times(1)
+
+				mockCognitarium := testutil.NewMockCognitariumQueryClient(controller)
+				mockCognitarium.
+					EXPECT().
+					Select(gomock.Any(), gomock.Any()).
+					Return(test.response, test.responseError).
+					Times(1)
+
+				client, err := dataverse.NewDataverseClient(context.Background(), mockDataverseClient, mockCognitarium)
+				So(err, ShouldBeNil)
+
+				Convey("When GetResourceGovAddr is called", func() {
+					addr, err := client.GetResourceGovAddr(context.Background(), test.resourceDID)
+
+					Convey("Then the resource governance address should be returned", func() {
+						if test.wantErr == nil {
+							So(err, ShouldBeNil)
+							So(addr, ShouldEqual, test.wantResult)
+						} else {
+							So(err.Error(), ShouldEqual, test.wantErr.Error())
+							So(addr, ShouldEqual, "")
 						}
 					})
 				})

--- a/dataverse/client_test.go
+++ b/dataverse/client_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+	dvschema "github.com/axone-protocol/axone-contract-schema/go/dataverse-schema/v5"
 	"github.com/axone-protocol/axone-sdk/dataverse"
 	"github.com/axone-protocol/axone-sdk/testutil"
 	. "github.com/smartystreets/goconvey/convey"
@@ -33,7 +33,7 @@ func TestClient_NewClient(t *testing.T) {
 				Convey("When Client is created", func() {
 					client, err := dataverse.NewClient(context.Background(), test.grpcAddr, test.contractAddr)
 
-					Convey("The client should be created of return an error", func() {
+					Convey("The client should be created or return an error", func() {
 						So(err.Error(), ShouldContainSubstring, test.wantErr.Error())
 						if test.wantErr == nil {
 							So(client, ShouldNotBeNil)
@@ -47,108 +47,27 @@ func TestClient_NewClient(t *testing.T) {
 	}
 }
 
-func toAddress[T any](v T) *T {
-	return &v
-}
-
-func TestClient_GetResourceGovAddr(t *testing.T) {
+func Test_GetCognitariumAddr(t *testing.T) {
 	tests := []struct {
-		name          string
-		resourceDID   string
-		response      *cgschema.SelectResponse
-		responseError error
-		wantErr       error
-		wantResult    string
+		name       string
+		address    string
+		err        error
+		wantErr    error
+		wantResult string
 	}{
 		{
-			name:        "ask for good did response",
-			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
-			response: &cgschema.SelectResponse{
-				Head: cgschema.Head{
-					Vars: []string{"code"},
-				},
-				Results: cgschema.Results{
-					Bindings: []map[string]cgschema.Value{
-						{
-							"code": cgschema.Value{
-								ValueType: cgschema.URI{
-									Type:  "uri",
-									Value: cgschema.IRI{Full: toAddress(cgschema.IRI_Full("foo"))},
-								},
-							},
-						},
-					},
-				},
-			},
-			responseError: nil,
-			wantErr:       nil,
-			wantResult:    "foo",
+			name:       "valid dataverse client",
+			address:    "addr",
+			err:        nil,
+			wantErr:    nil,
+			wantResult: "addr",
 		},
 		{
-			name:          "grpc error",
-			resourceDID:   "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
-			response:      nil,
-			responseError: fmt.Errorf("gRPC: connection refused"),
-			wantErr:       fmt.Errorf("gRPC: connection refused"),
-			wantResult:    "",
-		},
-		{
-			name:        "invalid variable binding in response",
-			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
-			response: &cgschema.SelectResponse{
-				Head: cgschema.Head{
-					Vars: []string{"code"},
-				},
-				Results: cgschema.Results{
-					Bindings: []map[string]cgschema.Value{
-						{
-							"invalid": cgschema.Value{},
-						},
-					},
-				},
-			},
-			responseError: nil,
-			wantErr:       dataverse.NewDVError(dataverse.ErrVarNotFound, nil),
-			wantResult:    "",
-		},
-		{
-			name:        "no binding in response",
-			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
-			response: &cgschema.SelectResponse{
-				Head: cgschema.Head{
-					Vars: []string{"code"},
-				},
-				Results: cgschema.Results{
-					Bindings: []map[string]cgschema.Value{},
-				},
-			},
-			responseError: nil,
-			wantErr:       dataverse.NewDVError(dataverse.ErrNoResult, nil),
-			wantResult:    "",
-		},
-		{
-			name:        "invalid value type in response",
-			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
-			response: &cgschema.SelectResponse{
-				Head: cgschema.Head{
-					Vars: []string{"code"},
-				},
-				Results: cgschema.Results{
-					Bindings: []map[string]cgschema.Value{
-						{
-							"code": cgschema.Value{
-								ValueType: cgschema.BlankNode{
-									Type:  "blank_node",
-									Value: "foo",
-								},
-							},
-						},
-					},
-				},
-			},
-			responseError: nil,
-			wantErr:       dataverse.NewDVError(dataverse.ErrType, fmt.Errorf("expected URI, got %T", cgschema.BlankNode{})),
-			wantResult:    "",
+			name:       "dataverse client return error",
+			address:    "",
+			err:        fmt.Errorf("error"),
+			wantErr:    fmt.Errorf("error"),
+			wantResult: "",
 		},
 	}
 
@@ -156,30 +75,30 @@ func TestClient_GetResourceGovAddr(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			Convey("Given a mocked dataverse client", t, func() {
 				controller := gomock.NewController(t)
-				defer controller.Finish()
+				mockDataverse := testutil.NewMockDataverseQueryClient(controller)
+				if test.err != nil {
+					mockDataverse.EXPECT().
+						Dataverse(gomock.Any(), gomock.Any()).
+						Return(nil, test.err).
+						Times(1)
+				} else {
+					mockDataverse.EXPECT().
+						Dataverse(gomock.Any(), gomock.Any()).
+						Return(&dvschema.DataverseResponse{TriplestoreAddress: dvschema.Addr(test.address)}, nil).
+						Times(1)
+				}
 
-				mockDataverseClient := testutil.NewMockDataverseQueryClient(controller)
+				Convey("When getCognitariumAddr is called", func() {
+					addr, err := dataverse.GetCognitariumAddr(context.Background(), mockDataverse)
 
-				mockCognitarium := testutil.NewMockCognitariumQueryClient(controller)
-				mockCognitarium.
-					EXPECT().
-					Select(gomock.Any(), gomock.Any()).
-					Return(test.response, test.responseError).
-					Times(1)
-
-				client, err := dataverse.NewDataverseClient(mockDataverseClient, mockCognitarium)
-				So(err, ShouldBeNil)
-
-				Convey("When GetResourceGovAddr is called", func() {
-					addr, err := client.GetResourceGovAddr(context.Background(), test.resourceDID)
-
-					Convey("Then the resource governance address should be returned", func() {
-						if test.wantErr == nil {
-							So(err, ShouldBeNil)
+					Convey("Then should return expected result or error", func() {
+						if test.err == nil {
 							So(addr, ShouldEqual, test.wantResult)
+							So(err, ShouldBeNil)
 						} else {
-							So(err.Error(), ShouldEqual, test.wantErr.Error())
 							So(addr, ShouldEqual, "")
+							So(err, ShouldNotBeNil)
+							So(err.Error(), ShouldEqual, test.wantErr.Error())
 						}
 					})
 				})

--- a/dataverse/client_test.go
+++ b/dataverse/client_test.go
@@ -50,8 +50,10 @@ func TestClient_NewDataverseClient(t *testing.T) {
 					).
 					Times(1)
 
+				mockCognitarium := testutil.NewMockCognitariumQueryClient(controller)
+
 				Convey("When Client is created", func() {
-					client, err := dataverse.NewDataverseClient(context.Background(), mockClient)
+					client, err := dataverse.NewDataverseClient(context.Background(), mockClient, mockCognitarium)
 
 					Convey("Then the client should be created if no error on dataverse client", func() {
 						So(err, ShouldEqual, test.wantErr)

--- a/dataverse/client_test.go
+++ b/dataverse/client_test.go
@@ -131,7 +131,7 @@ func TestClient_GetResourceGovAddr(t *testing.T) {
 				},
 			},
 			responseError: nil,
-			wantErr:       fmt.Errorf("could not find governance code"),
+			wantErr:       dataverse.NewDVError(dataverse.ErrVarNotFound, nil),
 			wantResult:    "",
 		},
 		{
@@ -146,7 +146,7 @@ func TestClient_GetResourceGovAddr(t *testing.T) {
 				},
 			},
 			responseError: nil,
-			wantErr:       fmt.Errorf("could not find governance code"),
+			wantErr:       dataverse.NewDVError(dataverse.ErrNoResult, nil),
 			wantResult:    "",
 		},
 		{
@@ -170,7 +170,7 @@ func TestClient_GetResourceGovAddr(t *testing.T) {
 				},
 			},
 			responseError: nil,
-			wantErr:       fmt.Errorf("could not decode governance code"),
+			wantErr:       dataverse.NewDVError(dataverse.ErrType, fmt.Errorf("expected URI, got %T", cgschema.BlankNode{})),
 			wantResult:    "",
 		},
 	}

--- a/dataverse/errors.go
+++ b/dataverse/errors.go
@@ -1,0 +1,30 @@
+package dataverse
+
+import "fmt"
+
+type MessageError string
+
+const (
+	ErrNoResult    MessageError = "no result found in binding"
+	ErrVarNotFound MessageError = "variable not found in binding result"
+	ErrType        MessageError = "variable result type mismatch in binding result"
+)
+
+type DVError struct {
+	message MessageError
+	detail  error
+}
+
+func (e *DVError) Error() string {
+	if e.detail == nil {
+		return fmt.Sprintf("%v", e.message)
+	}
+	return fmt.Sprintf("%v: %v", e.message, e.detail)
+}
+
+func NewDVError(message MessageError, detail error) error {
+	return &DVError{
+		message: message,
+		detail:  detail,
+	}
+}

--- a/dataverse/export_test.go
+++ b/dataverse/export_test.go
@@ -1,0 +1,18 @@
+package dataverse
+
+import (
+	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+	dvschema "github.com/axone-protocol/axone-contract-schema/go/dataverse-schema/v5"
+)
+
+func NewDataverseClient(
+	dataverseClient dvschema.QueryClient,
+	cognitariumClient cgschema.QueryClient,
+) Client {
+	return &client{
+		dataverseClient,
+		cognitariumClient,
+	}
+}
+
+var GetCognitariumAddr = getCognitariumAddr

--- a/dataverse/governance.go
+++ b/dataverse/governance.go
@@ -1,0 +1,34 @@
+package dataverse
+
+import (
+	"context"
+	"fmt"
+
+	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+)
+
+func (c *client) GetResourceGovAddr(ctx context.Context, resourceDID string) (string, error) {
+	query := buildGetResourceGovAddrRequest(resourceDID)
+	response, err := c.cognitariumClient.Select(ctx, &cgschema.QueryMsg_Select{Query: query})
+	if err != nil {
+		return "", err
+	}
+
+	if len(response.Results.Bindings) != 1 {
+		return "", NewDVError(ErrNoResult, nil)
+	}
+
+	codeBinding, ok := response.Results.Bindings[0]["code"]
+	if !ok {
+		return "", NewDVError(ErrVarNotFound, nil)
+	}
+	code, ok := codeBinding.ValueType.(cgschema.URI)
+	if !ok {
+		return "", NewDVError(ErrType, fmt.Errorf("expected URI, got %T", codeBinding.ValueType))
+	}
+	return string(*code.Value.Full), nil
+}
+
+func (c *client) ExecGov(_ context.Context, _ string, _ string) (interface{}, error) {
+	panic("not implemented")
+}

--- a/dataverse/governance_test.go
+++ b/dataverse/governance_test.go
@@ -1,0 +1,156 @@
+package dataverse_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+	"github.com/axone-protocol/axone-sdk/dataverse"
+	"github.com/axone-protocol/axone-sdk/testutil"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+)
+
+func toAddress[T any](v T) *T {
+	return &v
+}
+
+func TestClient_GetResourceGovAddr(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceDID   string
+		response      *cgschema.SelectResponse
+		responseError error
+		wantErr       error
+		wantResult    string
+	}{
+		{
+			name:        "ask for good did response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{
+						{
+							"code": cgschema.Value{
+								ValueType: cgschema.URI{
+									Type:  "uri",
+									Value: cgschema.IRI{Full: toAddress(cgschema.IRI_Full("foo"))},
+								},
+							},
+						},
+					},
+				},
+			},
+			responseError: nil,
+			wantErr:       nil,
+			wantResult:    "foo",
+		},
+		{
+			name:          "grpc error",
+			resourceDID:   "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response:      nil,
+			responseError: fmt.Errorf("gRPC: connection refused"),
+			wantErr:       fmt.Errorf("gRPC: connection refused"),
+			wantResult:    "",
+		},
+		{
+			name:        "invalid variable binding in response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{
+						{
+							"invalid": cgschema.Value{},
+						},
+					},
+				},
+			},
+			responseError: nil,
+			wantErr:       dataverse.NewDVError(dataverse.ErrVarNotFound, nil),
+			wantResult:    "",
+		},
+		{
+			name:        "no binding in response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{},
+				},
+			},
+			responseError: nil,
+			wantErr:       dataverse.NewDVError(dataverse.ErrNoResult, nil),
+			wantResult:    "",
+		},
+		{
+			name:        "invalid value type in response",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{
+						{
+							"code": cgschema.Value{
+								ValueType: cgschema.BlankNode{
+									Type:  "blank_node",
+									Value: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			responseError: nil,
+			wantErr:       dataverse.NewDVError(dataverse.ErrType, fmt.Errorf("expected URI, got %T", cgschema.BlankNode{})),
+			wantResult:    "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Convey("Given a mocked dataverse client", t, func() {
+				controller := gomock.NewController(t)
+				defer controller.Finish()
+
+				mockDataverseClient := testutil.NewMockDataverseQueryClient(controller)
+
+				mockCognitarium := testutil.NewMockCognitariumQueryClient(controller)
+				mockCognitarium.
+					EXPECT().
+					Select(gomock.Any(), gomock.Any()).
+					Return(test.response, test.responseError).
+					Times(1)
+
+				client := dataverse.NewDataverseClient(
+					mockDataverseClient,
+					mockCognitarium,
+				)
+
+				Convey("When GetResourceGovAddr is called", func() {
+					addr, err := client.GetResourceGovAddr(context.Background(), test.resourceDID)
+
+					Convey("Then the resource governance address should be returned", func() {
+						if test.wantErr == nil {
+							So(err, ShouldBeNil)
+							So(addr, ShouldEqual, test.wantResult)
+						} else {
+							So(err.Error(), ShouldEqual, test.wantErr.Error())
+							So(addr, ShouldEqual, "")
+						}
+					})
+				})
+			})
+		})
+	}
+}

--- a/dataverse/predicate.go
+++ b/dataverse/predicate.go
@@ -1,0 +1,9 @@
+package dataverse
+
+import cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+
+var (
+	VcBodySubject = cgschema.IRI_Full("dataverse:credential:body#subject")
+	VcBodyType    = cgschema.IRI_Full("dataverse:credential:body#type")
+	VcBodyClaim   = cgschema.IRI_Full("dataverse:credential:body#claim")
+)

--- a/dataverse/query.go
+++ b/dataverse/query.go
@@ -2,16 +2,18 @@ package dataverse
 
 import (
 	"fmt"
+
 	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
 )
 
 const W3IDPrefix = "https://w3id.org/axone/ontology/v4"
 
+//nolint:funlen
 func buildGetResourceGovAddrRequest(resource string) cgschema.SelectQuery {
 	limit := 1
-	selectVar := cgschema.SelectItem_Variable("code")
+	codeVar := cgschema.SelectItem_Variable("code")
 	codeVarOrNodeOrLit := cgschema.VarOrNodeOrLiteral_Variable("code")
-	credId := cgschema.VarOrNode_Variable("credId")
+	credIDVar := cgschema.VarOrNode_Variable("credId")
 	resourceIRI := cgschema.IRI_Full(resource)
 	govType := cgschema.IRI_Prefixed("gov:GovernanceTextCredential")
 	claimVar := cgschema.VarOrNode_Variable("claim")
@@ -31,36 +33,54 @@ func buildGetResourceGovAddrRequest(resource string) cgschema.SelectQuery {
 		},
 		Select: []cgschema.SelectItem{
 			{
-				Variable: &selectVar,
+				Variable: &codeVar,
 			},
 		},
 		Where: cgschema.WhereClause{
 			Bgp: &cgschema.WhereClause_Bgp{
 				Patterns: []cgschema.TriplePattern{
 					{
-						Subject:   cgschema.VarOrNode{Variable: &credId},
-						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodySubject}},
-						Object:    cgschema.VarOrNodeOrLiteral{Node: &cgschema.VarOrNodeOrLiteral_Node{NamedNode: &cgschema.Node_NamedNode{Full: &resourceIRI}}},
+						Subject: cgschema.VarOrNode{Variable: &credIDVar},
+						Predicate: cgschema.VarOrNamedNode{
+							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodySubject},
+						},
+						Object: cgschema.VarOrNodeOrLiteral{
+							Node: &cgschema.VarOrNodeOrLiteral_Node{
+								NamedNode: &cgschema.Node_NamedNode{Full: &resourceIRI},
+							},
+						},
 					},
 					{
-						Subject:   cgschema.VarOrNode{Variable: &credId},
-						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyType}},
-						Object:    cgschema.VarOrNodeOrLiteral{Node: &cgschema.VarOrNodeOrLiteral_Node{NamedNode: &cgschema.Node_NamedNode{Prefixed: &govType}}},
+						Subject: cgschema.VarOrNode{Variable: &credIDVar},
+						Predicate: cgschema.VarOrNamedNode{
+							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyType},
+						},
+						Object: cgschema.VarOrNodeOrLiteral{
+							Node: &cgschema.VarOrNodeOrLiteral_Node{
+								NamedNode: &cgschema.Node_NamedNode{Prefixed: &govType},
+							},
+						},
 					},
 					{
-						Subject:   cgschema.VarOrNode{Variable: &credId},
-						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyClaim}},
-						Object:    cgschema.VarOrNodeOrLiteral{Variable: &claimVarOrNode},
+						Subject: cgschema.VarOrNode{Variable: &credIDVar},
+						Predicate: cgschema.VarOrNamedNode{
+							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyClaim},
+						},
+						Object: cgschema.VarOrNodeOrLiteral{Variable: &claimVarOrNode},
 					},
 					{
-						Subject:   cgschema.VarOrNode{Variable: &claimVar},
-						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &isGovernedBy}},
-						Object:    cgschema.VarOrNodeOrLiteral{Variable: &govVarOrNodeOrLit},
+						Subject: cgschema.VarOrNode{Variable: &claimVar},
+						Predicate: cgschema.VarOrNamedNode{
+							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &isGovernedBy},
+						},
+						Object: cgschema.VarOrNodeOrLiteral{Variable: &govVarOrNodeOrLit},
 					},
 					{
-						Subject:   cgschema.VarOrNode{Variable: &govVar},
-						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &fromGovernance}},
-						Object:    cgschema.VarOrNodeOrLiteral{Variable: &codeVarOrNodeOrLit},
+						Subject: cgschema.VarOrNode{Variable: &govVar},
+						Predicate: cgschema.VarOrNamedNode{
+							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &fromGovernance},
+						},
+						Object: cgschema.VarOrNodeOrLiteral{Variable: &codeVarOrNodeOrLit},
 					},
 				},
 			},

--- a/dataverse/query.go
+++ b/dataverse/query.go
@@ -1,0 +1,63 @@
+package dataverse
+
+import cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+
+func buildGetResourceGovAddrRequest(resource string) cgschema.SelectQuery {
+	limit := 1
+	selectVar := cgschema.SelectItem_Variable("code")
+	codeVarOrNodeOrLit := cgschema.VarOrNodeOrLiteral_Variable("code")
+	credId := cgschema.VarOrNode_Variable("credId")
+	resourceIRI := cgschema.IRI_Full(resource)
+	govType := cgschema.IRI_Prefixed("gov:GovernanceTextCredential")
+	claimVar := cgschema.VarOrNode_Variable("claim")
+	claimVarOrNode := cgschema.VarOrNodeOrLiteral_Variable("claim")
+	isGovernedBy := cgschema.IRI_Prefixed("gov:isGovernedBy")
+	fromGovernance := cgschema.IRI_Prefixed("gov:fromGovernance")
+	govVarOrNodeOrLit := cgschema.VarOrNodeOrLiteral_Variable("gov")
+	govVar := cgschema.VarOrNode_Variable("gov")
+	return cgschema.SelectQuery{
+		Limit: &limit,
+		Prefixes: []cgschema.Prefix{
+			{
+				Prefix:    "gov",
+				Namespace: "https://w3id.org/axone/ontology/v4/schema/credential/governance/text/",
+			},
+		},
+		Select: []cgschema.SelectItem{
+			{
+				Variable: &selectVar,
+			},
+		},
+		Where: cgschema.WhereClause{
+			Bgp: &cgschema.WhereClause_Bgp{
+				Patterns: []cgschema.TriplePattern{
+					{
+						Subject:   cgschema.VarOrNode{Variable: &credId},
+						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodySubject}},
+						Object:    cgschema.VarOrNodeOrLiteral{Node: &cgschema.VarOrNodeOrLiteral_Node{NamedNode: &cgschema.Node_NamedNode{Full: &resourceIRI}}},
+					},
+					{
+						Subject:   cgschema.VarOrNode{Variable: &credId},
+						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyType}},
+						Object:    cgschema.VarOrNodeOrLiteral{Node: &cgschema.VarOrNodeOrLiteral_Node{NamedNode: &cgschema.Node_NamedNode{Prefixed: &govType}}},
+					},
+					{
+						Subject:   cgschema.VarOrNode{Variable: &credId},
+						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyClaim}},
+						Object:    cgschema.VarOrNodeOrLiteral{Variable: &claimVarOrNode},
+					},
+					{
+						Subject:   cgschema.VarOrNode{Variable: &claimVar},
+						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &isGovernedBy}},
+						Object:    cgschema.VarOrNodeOrLiteral{Variable: &govVarOrNodeOrLit},
+					},
+					{
+						Subject:   cgschema.VarOrNode{Variable: &govVar},
+						Predicate: cgschema.VarOrNamedNode{NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &fromGovernance}},
+						Object:    cgschema.VarOrNodeOrLiteral{Variable: &codeVarOrNodeOrLit},
+					},
+				},
+			},
+		},
+	}
+}

--- a/dataverse/query.go
+++ b/dataverse/query.go
@@ -1,6 +1,11 @@
 package dataverse
 
-import cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+import (
+	"fmt"
+	cgschema "github.com/axone-protocol/axone-contract-schema/go/cognitarium-schema/v5"
+)
+
+const W3IDPrefix = "https://w3id.org/axone/ontology/v4"
 
 func buildGetResourceGovAddrRequest(resource string) cgschema.SelectQuery {
 	limit := 1
@@ -15,12 +20,13 @@ func buildGetResourceGovAddrRequest(resource string) cgschema.SelectQuery {
 	fromGovernance := cgschema.IRI_Prefixed("gov:fromGovernance")
 	govVarOrNodeOrLit := cgschema.VarOrNodeOrLiteral_Variable("gov")
 	govVar := cgschema.VarOrNode_Variable("gov")
+
 	return cgschema.SelectQuery{
 		Limit: &limit,
 		Prefixes: []cgschema.Prefix{
 			{
 				Prefix:    "gov",
-				Namespace: "https://w3id.org/axone/ontology/v4/schema/credential/governance/text/",
+				Namespace: fmt.Sprintf("%s/schema/credential/governance/text/", W3IDPrefix),
 			},
 		},
 		Select: []cgschema.SelectItem{

--- a/dataverse/query.go
+++ b/dataverse/query.go
@@ -8,23 +8,14 @@ import (
 
 const W3IDPrefix = "https://w3id.org/axone/ontology/v4"
 
+func ref[T any](v T) *T {
+	return &v
+}
+
 //nolint:funlen
 func buildGetResourceGovAddrRequest(resource string) cgschema.SelectQuery {
-	limit := 1
-	codeVar := cgschema.SelectItem_Variable("code")
-	codeVarOrNodeOrLit := cgschema.VarOrNodeOrLiteral_Variable("code")
-	credIDVar := cgschema.VarOrNode_Variable("credId")
-	resourceIRI := cgschema.IRI_Full(resource)
-	govType := cgschema.IRI_Prefixed("gov:GovernanceTextCredential")
-	claimVar := cgschema.VarOrNode_Variable("claim")
-	claimVarOrNode := cgschema.VarOrNodeOrLiteral_Variable("claim")
-	isGovernedBy := cgschema.IRI_Prefixed("gov:isGovernedBy")
-	fromGovernance := cgschema.IRI_Prefixed("gov:fromGovernance")
-	govVarOrNodeOrLit := cgschema.VarOrNodeOrLiteral_Variable("gov")
-	govVar := cgschema.VarOrNode_Variable("gov")
-
 	return cgschema.SelectQuery{
-		Limit: &limit,
+		Limit: ref(1),
 		Prefixes: []cgschema.Prefix{
 			{
 				Prefix:    "gov",
@@ -33,54 +24,54 @@ func buildGetResourceGovAddrRequest(resource string) cgschema.SelectQuery {
 		},
 		Select: []cgschema.SelectItem{
 			{
-				Variable: &codeVar,
+				Variable: ref(cgschema.SelectItem_Variable("code")),
 			},
 		},
 		Where: cgschema.WhereClause{
 			Bgp: &cgschema.WhereClause_Bgp{
 				Patterns: []cgschema.TriplePattern{
 					{
-						Subject: cgschema.VarOrNode{Variable: &credIDVar},
+						Subject: cgschema.VarOrNode{Variable: ref(cgschema.VarOrNode_Variable("credId"))},
 						Predicate: cgschema.VarOrNamedNode{
 							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodySubject},
 						},
 						Object: cgschema.VarOrNodeOrLiteral{
 							Node: &cgschema.VarOrNodeOrLiteral_Node{
-								NamedNode: &cgschema.Node_NamedNode{Full: &resourceIRI},
+								NamedNode: &cgschema.Node_NamedNode{Full: ref(cgschema.IRI_Full(resource))},
 							},
 						},
 					},
 					{
-						Subject: cgschema.VarOrNode{Variable: &credIDVar},
+						Subject: cgschema.VarOrNode{Variable: ref(cgschema.VarOrNode_Variable("credId"))},
 						Predicate: cgschema.VarOrNamedNode{
 							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyType},
 						},
 						Object: cgschema.VarOrNodeOrLiteral{
 							Node: &cgschema.VarOrNodeOrLiteral_Node{
-								NamedNode: &cgschema.Node_NamedNode{Prefixed: &govType},
+								NamedNode: &cgschema.Node_NamedNode{Prefixed: ref(cgschema.IRI_Prefixed("gov:GovernanceTextCredential"))},
 							},
 						},
 					},
 					{
-						Subject: cgschema.VarOrNode{Variable: &credIDVar},
+						Subject: cgschema.VarOrNode{Variable: ref(cgschema.VarOrNode_Variable("credId"))},
 						Predicate: cgschema.VarOrNamedNode{
 							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Full: &VcBodyClaim},
 						},
-						Object: cgschema.VarOrNodeOrLiteral{Variable: &claimVarOrNode},
+						Object: cgschema.VarOrNodeOrLiteral{Variable: ref(cgschema.VarOrNodeOrLiteral_Variable("claim"))},
 					},
 					{
-						Subject: cgschema.VarOrNode{Variable: &claimVar},
+						Subject: cgschema.VarOrNode{Variable: ref(cgschema.VarOrNode_Variable("claim"))},
 						Predicate: cgschema.VarOrNamedNode{
-							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &isGovernedBy},
+							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: ref(cgschema.IRI_Prefixed("gov:isGovernedBy"))},
 						},
-						Object: cgschema.VarOrNodeOrLiteral{Variable: &govVarOrNodeOrLit},
+						Object: cgschema.VarOrNodeOrLiteral{Variable: ref(cgschema.VarOrNodeOrLiteral_Variable("gov"))},
 					},
 					{
-						Subject: cgschema.VarOrNode{Variable: &govVar},
+						Subject: cgschema.VarOrNode{Variable: ref(cgschema.VarOrNode_Variable("gov"))},
 						Predicate: cgschema.VarOrNamedNode{
-							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: &fromGovernance},
+							NamedNode: &cgschema.VarOrNamedNode_NamedNode{Prefixed: ref(cgschema.IRI_Prefixed("gov:fromGovernance"))},
 						},
-						Object: cgschema.VarOrNodeOrLiteral{Variable: &codeVarOrNodeOrLit},
+						Object: cgschema.VarOrNodeOrLiteral{Variable: ref(cgschema.VarOrNodeOrLiteral_Variable("code"))},
 					},
 				},
 			},


### PR DESCRIPTION
Implement the `GetResourceGovAddr` method to retrieve the governance contract address of a given resource DID by querying the Cognitarium.

It use the `axone-contract-schema` clients generated through `go-codegen`. Generated code use typealias to represent string and args require pointer to those typealias and require a little hack allowing to avoid create intermediate variable to give the typealias reference (`ref` helper).