### PR TITLE
feat(http): add listen method to http server

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -1,7 +1,12 @@
 package http
 
 import (
+	"context"
+	"errors"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -41,5 +46,31 @@ func WithOptions(opts ...Option) Option {
 func WithRoute(method, path string, handler http.Handler) Option {
 	return func(s *Server) {
 		s.router.Methods(method).Path(path).Handler(handler)
+	}
+}
+
+// Listen runs the server in a blocking way. In returns either if an error occur which in that case returns the error,
+// or if the server is stopped by a signal (i.e. `SIGINT` or `SIGTERM`).
+func (s *Server) Listen() error {
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- s.server.ListenAndServe()
+	}()
+
+	kill := make(chan os.Signal, 1)
+	signal.Notify(kill, syscall.SIGINT, syscall.SIGTERM)
+
+	for {
+		select {
+		case err := <-listenErr:
+			if errors.Is(err, http.ErrServerClosed) {
+				return nil
+			}
+			return err
+		case <-kill:
+			if err := s.server.Shutdown(context.Background()); err != nil {
+				return err
+			}
+		}
 	}
 }


### PR DESCRIPTION
Allow the http server to be served on a specified listen address.

## Details

Through the `func (s *Server) Listen() error` method, runs the server listening on the address configured.

This operation is blocking until either an interruption (i.e. through `SIGINT` or `SIGTERM`) or an error occurred, returning it if any.