### PR TITLE
Credential: put Parse method public

### DIFF
--- a/credential/generate.go
+++ b/credential/generate.go
@@ -66,7 +66,7 @@ func (generator *Generator) Generate() (*verifiable.Credential, error) {
 	if generator.parser == nil {
 		return nil, NewVCError(ErrNoParser, nil)
 	}
-	cred, err := generator.parser.parse(raw.Bytes())
+	cred, err := generator.parser.Parse(raw.Bytes())
 	if err != nil {
 		return nil, NewVCError(ErrParse, err)
 	}

--- a/credential/parser.go
+++ b/credential/parser.go
@@ -29,7 +29,7 @@ func NewDefaultParser(documentLoader ld.DocumentLoader) *DefaultParser {
 	return &DefaultParser{documentLoader: documentLoader}
 }
 
-func (cp *DefaultParser) parse(raw []byte) (*verifiable.Credential, error) {
+func (cp *DefaultParser) Parse(raw []byte) (*verifiable.Credential, error) {
 	vc, err := verifiable.ParseCredential(
 		raw,
 		verifiable.WithJSONLDValidation(),

--- a/testutil/dataverse_mocks.go
+++ b/testutil/dataverse_mocks.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	types "github.com/cosmos/cosmos-sdk/types"
 	verifiable "github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -109,11 +110,12 @@ func (m *MockDataverseTxClient) EXPECT() *MockDataverseTxClientMockRecorder {
 }
 
 // SubmitClaims mocks base method.
-func (m *MockDataverseTxClient) SubmitClaims(ctx context.Context, credential *verifiable.Credential) error {
+func (m *MockDataverseTxClient) SubmitClaims(ctx context.Context, credential *verifiable.Credential) (*types.TxResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitClaims", ctx, credential)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*types.TxResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SubmitClaims indicates an expected call of SubmitClaims.


### PR DESCRIPTION
Make the Parse method public allowing us to reuse in external lib. 