### PR TITLE
Fix/make it work

### DIFF
--- a/dataverse/governance.go
+++ b/dataverse/governance.go
@@ -28,7 +28,14 @@ func (c *queryClient) GetResourceGovAddr(ctx context.Context, resourceDID string
 	if !ok {
 		return "", NewDVError(ErrType, fmt.Errorf("expected URI, got %T", codeBinding.ValueType))
 	}
-	return string(*code.Value.Full), nil
+
+	codeURI := string(*code.Value.Full)
+	addr := codeURI
+	if i := strings.LastIndex(string(*code.Value.Full), ":"); i != -1 {
+		addr = codeURI[i+1:]
+	}
+
+	return addr, nil
 }
 
 func (c *queryClient) AskGovPermittedActions(ctx context.Context, addr, did string) ([]string, error) {

--- a/dataverse/governance_test.go
+++ b/dataverse/governance_test.go
@@ -51,6 +51,30 @@ func TestClient_GetResourceGovAddr(t *testing.T) {
 			wantResult:    "foo",
 		},
 		{
+			name:        "ask for good did response with addr in uri",
+			resourceDID: "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
+			response: &cgschema.SelectResponse{
+				Head: cgschema.Head{
+					Vars: []string{"code"},
+				},
+				Results: cgschema.Results{
+					Bindings: []map[string]cgschema.Value{
+						{
+							"code": cgschema.Value{
+								ValueType: cgschema.URI{
+									Type:  "uri",
+									Value: cgschema.IRI{Full: toAddress(cgschema.IRI_Full("contract:law-stone:foo"))},
+								},
+							},
+						},
+					},
+				},
+			},
+			responseError: nil,
+			wantErr:       nil,
+			wantResult:    "foo",
+		},
+		{
 			name:          "grpc error",
 			resourceDID:   "did:key:zQ3shuwMJWYXRi64qiGojsV9bPN6Dtugz5YFM2ESPtkaNxTZ5",
 			response:      nil,

--- a/provider/storage/http.go
+++ b/provider/storage/http.go
@@ -17,7 +17,7 @@ func (p *Proxy) HTTPConfigurator(jwtSecretKey []byte, jwtTTL time.Duration) axon
 	jwtFactory := jwt.NewFactory(jwtSecretKey, p.key.DID(), jwtTTL)
 
 	return axonehttp.WithOptions(
-		axonehttp.WithRoute(http.MethodGet, "/authenticate", jwtFactory.HTTPAuthHandler(p)),
+		axonehttp.WithRoute(http.MethodPost, "/authenticate", jwtFactory.HTTPAuthHandler(p)),
 		axonehttp.WithRoute(http.MethodGet, "/{path}", jwtFactory.VerifyHTTPMiddleware(p.HTTPReadHandler())),
 		axonehttp.WithRoute(http.MethodPost, "/{path}", jwtFactory.VerifyHTTPMiddleware(p.HTTPStoreHandler())),
 	)

--- a/provider/storage/proxy.go
+++ b/provider/storage/proxy.go
@@ -75,7 +75,7 @@ func (p *Proxy) Read(ctx context.Context, id *auth.Identity, resourceID string) 
 		return nil, err
 	}
 
-	ok, err := p.dvClient.AskGovTellAction(ctx, govAddr, p.key.DID(), readAction)
+	ok, err := p.dvClient.AskGovTellAction(ctx, govAddr, id.DID, readAction)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some fix to make it work:
- Allow retrieving law stone governance contract address in URI, for example: `contract:law-stone:$ADDR`. This is needed for now as the governance credential only allow named nodes so a literal address is not compliant;
- The `/authenticate` endpoint is now exposed on a `POST` http method so we can provide the credential as body;
- The read access check against the data governance is made considering the identity requesting it;