### PR TITLE
ci(workflow): add notify-github-discussion job

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,77 @@
+name: Notify release
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (leave empty for last one)"
+
+jobs:
+  set-env:
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.set-env.outputs.tag }}
+      repo_name: ${{ steps.set-env.outputs.repo_name }}
+    steps:
+      - name: Expose tag and repo_name
+        id: set-env
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG=$(gh release view --json tagName -q '.tagName')
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+          REPO_NAME=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}
+          echo "repo_name=$REPO_NAME" >> $GITHUB_OUTPUT
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+
+  notify-github-discussion:
+    runs-on: ubuntu-22.04
+    needs: set-env
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Extract changelog for tag
+        run: |
+          {
+            echo 'CHANGELOG<<EOF'
+            gh release view ${{ needs.set-env.outputs.tag }} --json body -q '.body'
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.OPS_TOKEN }}
+
+      - name: Create an announcement discussion for release
+        uses: abirismyname/create-discussion@v1.2.0
+        with:
+          title: 🎉 ${{ needs.set-env.outputs.repo_name }} ${{ needs.set-env.outputs.tag }} released!
+          body: |
+            Hey frens! [${{ github.repository }}](https://github.com/${{ github.repository }}) `${{ needs.set-env.outputs.tag }}` just dropped! 🚀
+
+            Some fresh updates are here. Dive into the changelog and see what's cooking! 🔥
+
+            # Changelog
+
+            ${{ env.CHANGELOG }}
+
+            # Resources
+
+            📄 Changelog: <https://github.com/${{ github.repository }}/releases/tag/${{ needs.set-env.outputs.tag }}>
+            🛠️ Official repo: <https://github.com/${{ github.repository }}>
+            💬 Vibe with us on Discord: <${{ env.DISCORD_URL }}>
+            🐦 Catch us on X: <${{ env.TWITTER_URL }}>
+          repository-id: ${{ env.REPOSITORY_ID }}
+          category-id: ${{ env.CATEGORY_ID }}
+        env:
+          GH_TOKEN: ${{ secrets.OPS_TOKEN }}
+          DISCORD_URL: ${{ vars.DISCORD_URL }}
+          TWITTER_URL: ${{ vars.TWITTER_URL }}
+          REPOSITORY_ID: ${{ vars.DISCUSSIONS_REPOSITORY_ID }}
+          CATEGORY_ID: ${{ vars.DISCUSSIONS_CATEGORY_ID }}


### PR DESCRIPTION
Addresses https://github.com/axone-protocol/community/issues/6.

- Additionally, removes Discord notifications on release, as [GitHub Discussions](https://github.com/orgs/axone-protocol/discussions) will now serve as the primary release notification channel, with optional forwarding to Discord if needed.
- Also enables manual triggering with a specific tag input (only for the notification of release on discussions), alongside the default trigger on release. This adds flexibility for replaying the workflow when necessary.​