### PR TITLE
ci(workflow): add missing workflow_call to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,13 @@
 name: Lint
 
 on:
+  workflow_call:
+
   push:
-    branches: [ main ]
+    branches: [main]
 
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Self explanatory.

(required for release)