### PR TITLE
fix(srv): avoid unnecessary HTTP 200 status write

### DIFF
--- a/provider/storage/http.go
+++ b/provider/storage/http.go
@@ -44,7 +44,6 @@ func (p *Proxy) HTTPReadHandler() auth.AuthenticatedHandler {
 			writer.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		writer.WriteHeader(http.StatusOK)
 	}
 }
 


### PR DESCRIPTION
Fixes superfluous `response.WriteHeader` call:

```text
s3-auth-proxy  | 2025/03/13 17:16:27 http: superfluous response.WriteHeader call from github.com/axone-protocol/axone-sdk/provider/storage.(*Proxy).HTTPConfigurator.(*Proxy).HTTPReadHandler.func3 (http.go:39)
```