### PR TITLE
chore(deps): bump golangci-lint from v1.62 to v2.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,7 +74,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
-          version: v1.62
+          version: v2.0
 
       - name: Lint go code (gofumpt)
         if: steps.changed-go-files.outputs.any_changed == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-run:
-  timeout: 10m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bidichk
@@ -17,17 +15,14 @@ linters:
     - exhaustive
     - forbidigo
     - funlen
-    - gci
     - gocognit
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - goimports
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -43,58 +38,75 @@ linters:
     - promlinter
     - revive
     - staticcheck
-    - stylecheck
     - tagliatelle
-    - tenv
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - wastedassign
     - whitespace
-
-linters-settings:
-  cyclop:
-    max-complexity: 20
-    skip-tests: true
-  funlen:
-    statements: 65
-  godot:
-    scope: declarations # comments to be checked: `declarations` (default), `toplevel`, or `all`
-  lll:
-    line-length: 135
-  tagliatelle:
-    case:
-      use-field-name: true
-      rules:
-        json: snake
-        yaml: snake
-output:
-  uniq-by-line: false
-
+  settings:
+    cyclop:
+      max-complexity: 20
+    funlen:
+      statements: 65
+    godot:
+      scope: declarations
+    lll:
+      line-length: 135
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          yaml: snake
+        use-field-name: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: ^//\s*go:generate\s
+      - linters:
+          - godot
+        source: (noinspection|TODO)
+      - linters:
+          - gocritic
+        source: //noinspection
+      - linters:
+          - errorlint
+        source: ^\s+if _, ok := err\.\([^.]+\.InternalError\); ok {
+      - linters:
+          - dupl
+          - funlen
+          - goconst
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test\.go
+        text: "dot-imports:"
+      - linters:
+          - cyclop
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    - source: "^//\\s*go:generate\\s"
-      linters:
-        - lll
-    - source: "(noinspection|TODO)"
-      linters:
-        - godot
-    - source: "//noinspection"
-      linters:
-        - gocritic
-    - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
-      linters:
-        - errorlint
-    - path: "_test\\.go"
-      linters:
-        - dupl
-        - funlen
-        - goconst
-    - path: "_test\\.go"
-      linters:
-        - revive
-      text: "dot-imports:"
+  uniq-by-line: false
+formatters:
+  enable:
+    - gci
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET_FOLDER = target
 
 # Docker images
 DOCKER_IMAGE_GOLANG    = golang:1.21-alpine3.17
-DOCKER_IMAGE_GOLANG_CI = golangci/golangci-lint:v1.62
+DOCKER_IMAGE_GOLANG_CI = golangci/golangci-lint:v2.0
 
 # Some colors
 COLOR_GREEN  = $(shell tput -Txterm setaf 2)


### PR DESCRIPTION
Adopt [golangci-lint](https://golangci-lint.run/) v2.0 - because it’s cute, strict, and just wants the best for our code.
Applied [config migration](https://golangci-lint.run/product/migration-guide) and updated codebase to comply with the new linter rules.