### PR TITLE
Feat/governance code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: test-go ## Pass all the tests
 .PHONY: test-go
 test-go: build ## Pass the test for the go source code
 	@echo "${COLOR_CYAN} 🧪 Passing go tests${COLOR_RESET}"
-	@mkdir $(TARGET_FOLDER)
+	@mkdir -p $(TARGET_FOLDER)
 	@go test -v -coverprofile $(TARGET_FOLDER)/coverage.txt ./...
 
 ## Clean:

--- a/dataverse/client.go
+++ b/dataverse/client.go
@@ -35,6 +35,9 @@ type QueryClient interface {
 	// ```
 	// The function returns true if Result is 'permitted', false otherwise.
 	AskGovTellAction(context.Context, string, string, string) (bool, error)
+
+	// GovCode retrieves the governance code given its address (law-stone contract address)
+	GovCode(context.Context, string) (string, error)
 }
 
 type TxClient interface {

--- a/dataverse/governance.go
+++ b/dataverse/governance.go
@@ -2,6 +2,7 @@ package dataverse
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -36,6 +37,28 @@ func (c *queryClient) GetResourceGovAddr(ctx context.Context, resourceDID string
 	}
 
 	return addr, nil
+}
+
+func (c *queryClient) GovCode(ctx context.Context, addr string) (string, error) {
+	gov, err := c.lawStoneFactory(addr)
+	if err != nil {
+		return "", fmt.Errorf("failed to create law-stone client: %w", err)
+	}
+
+	code, err := gov.ProgramCode(ctx, &lsschema.QueryMsg_ProgramCode{})
+	if err != nil {
+		return "", fmt.Errorf("failed to query law-stone contract: %w", err)
+	}
+	if code == nil {
+		return "", nil
+	}
+
+	decodedCode, err := base64.StdEncoding.DecodeString(*code)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode law-stone code: %w", err)
+	}
+
+	return string(decodedCode), nil
 }
 
 func (c *queryClient) AskGovPermittedActions(ctx context.Context, addr, did string) ([]string, error) {

--- a/testutil/dataverse_mocks.go
+++ b/testutil/dataverse_mocks.go
@@ -86,6 +86,21 @@ func (mr *MockQueryClientMockRecorder) GetResourceGovAddr(arg0, arg1 any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceGovAddr", reflect.TypeOf((*MockQueryClient)(nil).GetResourceGovAddr), arg0, arg1)
 }
 
+// GovCode mocks base method.
+func (m *MockQueryClient) GovCode(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GovCode", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GovCode indicates an expected call of GovCode.
+func (mr *MockQueryClientMockRecorder) GovCode(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GovCode", reflect.TypeOf((*MockQueryClient)(nil).GovCode), arg0, arg1)
+}
+
 // MockDataverseTxClient is a mock of TxClient interface.
 type MockDataverseTxClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Add `GovCode` function for accessing _governance code_ (prolog) stored in the [law-stone](https://docs.axone.xyz/contracts/axone-law-stone) smart contract instance.
