### PR TITLE
ci(workflow): fix insufficient permissions for nested lint job in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   lint:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
     uses: ./.github/workflows/lint.yml
+    permissions:
+      actions: read
+      security-events: write
 
   build:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'


### PR DESCRIPTION
Ensure correct permissions are passed to the `lint` job when called from the `release` workflow (help CodeQL analysis to run properly).