### PR TITLE
 ci(workflow): fix insufficient permissions for nested lint job (2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/lint.yml
     permissions:
       actions: read
+      contents: read
       security-events: write
 
   build:


### PR DESCRIPTION
Continuation of #71. Adds the required _contents_ permission to ensure proper workflow execution.