### PR TITLE
ci(workflow): add conditional check to analyze-go job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,20 +110,24 @@ jobs:
 
       - name: Setup Go environment
         uses: actions/setup-go@v5.4.0
+        if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
           go-version: "1.21"
           cache: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
+        if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
           languages: "go"
 
       - name: Autobuild project
         uses: github/codeql-action/autobuild@v3
+        if: steps.changed-go-files.outputs.any_changed == 'true'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
+        if: steps.changed-go-files.outputs.any_changed == 'true'
 
   lint-shell:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Add missing conditions the `analyze-go` job on file changes to avoid unnecessary _CodeQL_ runs.